### PR TITLE
Allow the use of custom endpoints with the AWS SecretsManager Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ aws_secrets:
   client_config:
     region:           # Required if "ignore" is false.
     version: 'latest' # Defaults to "latest".
+    endpoint: ~
     credentials: 
         key: ~
         secret: ~

--- a/src/DependencyInjection/AwsSecretsExtension.php
+++ b/src/DependencyInjection/AwsSecretsExtension.php
@@ -41,6 +41,7 @@ class AwsSecretsExtension extends Extension
             ->setPublic(false)
             ->addArgument($configs['client_config']['region'])
             ->addArgument($configs['client_config']['version'])
+            ->addArgument($configs['client_config']['endpoint'])
             ->addArgument($configs['client_config']['credentials']['key'])
             ->addArgument($configs['client_config']['credentials']['secret'])
             ->setFactory([SecretsManagerClientFactory::class, 'createClient']);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->scalarNode('region')->defaultNull()->end()
                         ->scalarNode('version')->defaultValue('latest')->end()
+                        ->scalarNode('endpoint')->defaultNull()->end()
                         ->arrayNode('credentials')
                             ->addDefaultsIfNotSet()
                             ->children()

--- a/src/DependencyInjection/SecretsManagerClientFactory.php
+++ b/src/DependencyInjection/SecretsManagerClientFactory.php
@@ -22,6 +22,7 @@ class SecretsManagerClientFactory
     public static function createClient(
         string $region,
         string $version,
+        ?string $endpoint, 
         ?string $key,
         ?string $secret
     ): SecretsManagerClient {
@@ -37,6 +38,10 @@ class SecretsManagerClientFactory
             ];
         } elseif (($key && !$secret) || (!$key && $secret)) {
             throw new Exception('Both key and secret must be provided or neither');
+        }
+
+        if ($endpoint) {
+            $config['endpoint'] = $endpoint;
         }
 
         return new SecretsManagerClient($config);

--- a/tests/DependencyInjection/SecretsManagerClientFactoryTest.php
+++ b/tests/DependencyInjection/SecretsManagerClientFactoryTest.php
@@ -16,6 +16,7 @@ class SecretsManagerClientFactoryTest extends TestCase
         $factory->createClient(
             'region',
             'latest',
+            null,
             'key',
             null
         );
@@ -30,6 +31,7 @@ class SecretsManagerClientFactoryTest extends TestCase
             'region',
             'latest',
             null,
+            null,
             'secret'
         );
     }
@@ -41,6 +43,7 @@ class SecretsManagerClientFactoryTest extends TestCase
         $client = $factory->createClient(
             'region',
             'latest',
+            null,
             null,
             null
         );
@@ -54,8 +57,23 @@ class SecretsManagerClientFactoryTest extends TestCase
         $client = $factory->createClient(
             'region',
             'latest',
+            null,
             'key',
             'secret'
+        );
+        $this->assertInstanceOf(SecretsManagerClient::class, $client);
+    }
+
+    /** @test */
+    public function it_builds_client_with_endpoint(): void
+    {
+        $factory = new SecretsManagerClientFactory();
+        $client = $factory->createClient(
+            'region',
+            'latest',
+            'http://my-endpoint.example.com:4566',
+            null,
+            null
         );
         $this->assertInstanceOf(SecretsManagerClient::class, $client);
     }


### PR DESCRIPTION
Changes made allow developers to use [localstack](https://github.com/localstack/localstack) as a substitute for real AWS services.